### PR TITLE
Quote strings made by convert-to-emojipack

### DIFF
--- a/bin/convert-to-emojipack
+++ b/bin/convert-to-emojipack
@@ -67,13 +67,13 @@ co(function *() {
     Object.keys(compiledEmojis).forEach((name) => {
       var emoji = compiledEmojis[name];
 
-      stream.write(`  - name: ${emoji.name}\n`);
+      stream.write(`  - name: "${emoji.name}"\n`);
 
       // Write the aliases array if any exist
       if (emoji.aliases && emoji.aliases.length > 0) {
         stream.write('    aliases:\n');
         emoji.aliases.forEach((alias) => {
-          stream.write(`      - ${alias}\n`);
+          stream.write(`      - "${alias}"\n`);
         });
       }
 


### PR DESCRIPTION
* We have some weird emoji, for example :-: and :null:.
* This confuses yaml parsers immensely, and the easy solution is just to
quote strings that are reserve words for node or yaml.
* This change quotes all emoji names and aliases when generating an
emoji yaml to avoid those issues